### PR TITLE
fix(ios): release camera and defer actions across native Modal lifecycle

### DIFF
--- a/src/components/QrScannerModal.android.tsx
+++ b/src/components/QrScannerModal.android.tsx
@@ -225,6 +225,9 @@ export const QrScannerModal: React.FC<QrScannerModalProps> = ({ visible, onClose
   );
 
   const renderBody = () => {
+    // modal 不可见时卸载相机:RN <Modal> 关闭不会卸载子节点,而 CameraView 一旦
+    // 挂载就占用摄像头。expo-camera 的 active 属性仅 iOS 生效,安卓只能靠卸载释放。
+    if (!visible) return null;
     if (!permission) return renderPermissionPending();
     if (!permission.granted) return renderPermissionDenied();
     return renderScanner();

--- a/src/components/QrScannerModal.ios.tsx
+++ b/src/components/QrScannerModal.ios.tsx
@@ -189,6 +189,9 @@ export const QrScannerModal: React.FC<QrScannerModalProps> = ({ visible, onClose
   const renderScanner = () => (
     <View style={styles.scannerRoot}>
       <CameraView
+        // active 随 modal 可见性联动:RN <Modal> 关闭(visible=false)时不会卸载
+        // 子节点,若不停掉相机会话,expo-camera 会一直占用摄像头(灵动岛绿灯常亮)。
+        active={visible}
         style={StyleSheet.absoluteFill}
         facing="back"
         enableTorch={torchOn}

--- a/src/hooks/useCardContextTransition.ts
+++ b/src/hooks/useCardContextTransition.ts
@@ -123,7 +123,13 @@ export function useCardContextTransition(anchor: CardAnchorRect | null, onDismis
       closingRef.current = true;
       const finish = () => {
         onDismiss();
-        after?.();
+        // 把选中动作推迟到浮层的原生 <Modal> 真正卸载/dismiss 之后再执行。
+        // 若在同一 tick 里紧接着 present 系统面板(如分享 sheet),会在
+        // iOS 16.x 上构成 present-while-dismissing 而冻结整个界面。浮层是
+        // animationType="none",卸载几乎瞬时,隔两帧即可让 dismiss 完成。
+        if (after) {
+          requestAnimationFrame(() => requestAnimationFrame(after));
+        }
       };
       progress.value = withTiming(
         0,


### PR DESCRIPTION
## Problem

React Native's `<Modal>` does not unmount its children when `visible` flips to `false` — it only hides them. Native resources attached to those child views therefore leak past the visual dismissal.

## Fixes

**QrScannerModal** — the `CameraView` kept the camera session alive after the scanner modal closed, leaving the iOS Dynamic Island camera (green) indicator lit.
- iOS: `active={visible}` stops the capture session when hidden.
- Android: `expo-camera`'s `active` prop is iOS-only, so the modal body is unmounted when `!visible` to actually release the camera.

**useCardContextTransition** — dismissing the context overlay's `<Modal>` and presenting a system sheet (e.g. the share sheet) in the same tick constituted a present-while-dismissing on iOS 16.x, freezing the UI. The selected action is now deferred two frames (`requestAnimationFrame` ×2) until the dismiss settles; the overlay uses `animationType="none"` so unmount is near-instant.

## Scope

Small, self-contained (13 lines). No behavior change when modals are open — only the hidden/closing transitions are affected.