### PR TITLE
fix(update): 修正镜像下载渠道 GitCode → Gitee

### DIFF
--- a/src/i18n/locales/en/settingsAbout.json
+++ b/src/i18n/locales/en/settingsAbout.json
@@ -19,7 +19,7 @@
     "latestVersion": "Latest version: {{version}}",
     "currentVersion": "Current version: {{version}}",
     "releaseNotes": "Release notes:\n{{notes}}",
-    "gitcode": "Download from GitCode",
+    "gitee": "Download from Gitee",
     "github": "Download from GitHub",
     "downloading": "Downloading {{percent}}%",
     "canceled": "Download canceled",

--- a/src/i18n/locales/zh/settingsAbout.json
+++ b/src/i18n/locales/zh/settingsAbout.json
@@ -19,7 +19,7 @@
     "latestVersion": "最新版本：{{version}}",
     "currentVersion": "当前版本：{{version}}",
     "releaseNotes": "更新说明：\n{{notes}}",
-    "gitcode": "GitCode 下载",
+    "gitee": "Gitee 下载",
     "github": "GitHub 下载",
     "downloading": "下载中 {{percent}}%",
     "canceled": "已取消下载",

--- a/src/screens/settings/AboutSection.tsx
+++ b/src/screens/settings/AboutSection.tsx
@@ -265,11 +265,11 @@ export const AboutSection = memo(function AboutSection() {
                   onClick={() => {
                     const s = downloadSourceSheet;
                     setDownloadSourceSheet(null);
-                    handleDownloadApk('gitcode', s.version, s.assets);
+                    handleDownloadApk('gitee', s.version, s.assets);
                   }}
                   modifiers={[fillMaxWidth()]}
                 >
-                  <ComposeText>{t('download.gitcode')}</ComposeText>
+                  <ComposeText>{t('download.gitee')}</ComposeText>
                 </Button>
                 <Spacer modifiers={[heightModifier(8)]} />
                 <OutlinedButton

--- a/src/services/ApkDownloadService.ts
+++ b/src/services/ApkDownloadService.ts
@@ -72,7 +72,7 @@ export function cleanOldApkCache(currentVersion: string): void {
   }
 }
 
-export type ApkSource = 'github' | 'gitcode';
+export type ApkSource = 'github' | 'gitee';
 
 const SUPPORTED_ABI_NAMES = ['arm64-v8a', 'armeabi-v7a', 'x86_64'] as const;
 type ApkAbi = (typeof SUPPORTED_ABI_NAMES)[number] | 'universal';
@@ -151,7 +151,7 @@ export async function checkApkCache(
  */
 export async function downloadApk(options: ApkDownloadOptions): Promise<string> {
   const { asset, source, version, onProgress, signal } = options;
-  const url = source === 'github' ? asset.githubDownloadUrl : asset.gitcodeDownloadUrl;
+  const url = source === 'github' ? asset.githubDownloadUrl : asset.giteeDownloadUrl;
   log.info(`[ApkDownload] start source=${source} url=${url}`);
 
   // 确保缓存目录存在（含父目录）

--- a/src/services/UpdateService.ts
+++ b/src/services/UpdateService.ts
@@ -5,11 +5,11 @@
 
 const GITHUB_RELEASES_API = 'https://api.github.com/repos/UniClipboard/uc-android/releases';
 const RELEASES_PAGE_URL = 'https://github.com/UniClipboard/uc-android/releases';
-// NOTE: GitCode 的 release 资源下载 URL 模式按 GitHub 风格猜测,
-// 首次在 GitCode 发布 release 后,必须人工点开下载链接验证路径是否对得上,
-// 若 GitCode 实际使用其他模式(如 GitLab 风格 /-/releases/<tag>/downloads/<file>),需相应调整下方两行模板
-const GITCODE_RELEASES_PAGE_URL = 'https://gitcode.com/UniClipboard/uc-android/releases';
-const GITCODE_DOWNLOAD_BASE = 'https://gitcode.com/UniClipboard/uc-android/releases/download';
+// Gitee 镜像渠道。仓库路径由 CI 的 GITEE_OWNER/GITEE_REPO 决定(uni-clipboard/uc-android),
+// 与 GitHub 侧的 UniClipboard/uc-android 大小写/写法不同,勿直接沿用 GitHub 命名空间。
+// Gitee release 附件下载 URL 采用 /releases/download/<tag>/<file> 模式,与 GitHub 一致。
+const GITEE_RELEASES_PAGE_URL = 'https://gitee.com/uni-clipboard/uc-android/releases';
+const GITEE_DOWNLOAD_BASE = 'https://gitee.com/uni-clipboard/uc-android/releases/download';
 
 export interface ParsedVersion {
   major: number;
@@ -24,8 +24,8 @@ export interface ReleaseAssetInfo {
   name: string;
   /** GitHub 直接下载 URL */
   githubDownloadUrl: string;
-  /** GitCode 直接下载 URL */
-  gitcodeDownloadUrl: string;
+  /** Gitee 直接下载 URL */
+  giteeDownloadUrl: string;
   /** SHA-256 哈希值（十六进制小写），来自 GitHub API digest 字段，可能为 undefined */
   sha256?: string;
 }
@@ -88,7 +88,7 @@ export interface UpdateCheckResult {
   latestVersion: string;
   tagName: string;
   releaseUrl: string;
-  gitcodeReleaseUrl: string;
+  giteeReleaseUrl: string;
   /** APK 资源列表（含各 ABI 的下载 URL 和哈希值） */
   assets: ReleaseAssetInfo[];
   /** GitHub Release 更新说明 */
@@ -139,7 +139,7 @@ export async function checkForUpdate(
       latestVersion: currentVersionStr,
       tagName: '',
       releaseUrl: RELEASES_PAGE_URL,
-      gitcodeReleaseUrl: GITCODE_RELEASES_PAGE_URL,
+      giteeReleaseUrl: GITEE_RELEASES_PAGE_URL,
       assets: [],
       releaseNotes: undefined,
     };
@@ -153,7 +153,7 @@ export async function checkForUpdate(
     .map((a) => ({
       name: a.name,
       githubDownloadUrl: a.browser_download_url,
-      gitcodeDownloadUrl: `${GITCODE_DOWNLOAD_BASE}/${latest.tag_name}/${a.name}`,
+      giteeDownloadUrl: `${GITEE_DOWNLOAD_BASE}/${latest.tag_name}/${a.name}`,
       sha256: a.digest?.startsWith('sha256:') ? a.digest.slice(7).toLowerCase() : undefined,
     }));
 
@@ -163,7 +163,7 @@ export async function checkForUpdate(
       latestVersion: latest.tag_name,
       tagName: latest.tag_name,
       releaseUrl: latest.html_url,
-      gitcodeReleaseUrl: `https://gitcode.com/UniClipboard/uc-android/releases/tag/${latest.tag_name}`,
+      giteeReleaseUrl: `https://gitee.com/uni-clipboard/uc-android/releases/tag/${latest.tag_name}`,
       assets: apkAssets,
       releaseNotes: latest.body,
     };
@@ -175,7 +175,7 @@ export async function checkForUpdate(
     latestVersion: versionToStr(latestParsed),
     tagName: latest.tag_name,
     releaseUrl: latest.html_url,
-    gitcodeReleaseUrl: `https://gitcode.com/UniClipboard/uc-android/releases/tag/${latest.tag_name}`,
+    giteeReleaseUrl: `https://gitee.com/uni-clipboard/uc-android/releases/tag/${latest.tag_name}`,
     assets: apkAssets,
     releaseNotes: latest.body,
   };


### PR DESCRIPTION
## 问题

App 内的第二更新渠道 UI 叫「GitCode」,URL 却指向 `gitcode.com`(CSDN 平台),而 CI 实际把 APK 镜像发布到的是 **`gitee.com`(码云)**——两个完全不同的平台。release 从未发到 gitcode.com,因此该渠道点击后必然 404。

此外仓库 owner 也不一致:App 硬编码 GitHub 侧的 `UniClipboard`,而 Gitee 侧是 `uni-clipboard`。

## 改动

全链路把「GitCode」改为「Gitee」,并对齐 CI 的 `GITEE_OWNER/GITEE_REPO`(`uni-clipboard/uc-android`):

- `src/services/UpdateService.ts` —— 常量域名 `gitcode.com/UniClipboard` → `gitee.com/uni-clipboard`;字段 `gitcodeDownloadUrl`/`gitcodeReleaseUrl` → `giteeDownloadUrl`/`giteeReleaseUrl`;更新注释说明镜像来自 CI 变量
- `src/services/ApkDownloadService.ts` —— `ApkSource` 类型 `'gitcode'` → `'gitee'`,选源逻辑改用 `giteeDownloadUrl`
- `src/screens/settings/AboutSection.tsx` —— 按钮回调与文案 key 改为 `gitee`
- `src/i18n/locales/{zh,en}/settingsAbout.json` —— 文案改为「Gitee 下载」/「Download from Gitee」

Gitee 的 release 附件下载 URL 模式(`/releases/download/<tag>/<file>`)与 GitHub 一致,现有拼接逻辑直接复用。

## 验证

- `tsc --noEmit` 通过,无 gitcode 残留引用
- ⚠️ 待人工验证:下个 release 出来后点一次「Gitee 下载」,确认真实 APK 可下载(首次真正对齐平台)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Replaced GitCode with Gitee as the alternate APK download source.
  * Updated download labels and release links in English and Chinese.
  * APK downloads and update checks now use Gitee mirrors while retaining existing progress and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->