### PR TITLE
feat: forward mobile connection opportunities

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,10 @@ Legacy responses without the newer fields remain readable.
   app lifecycle and background policy.
 - `UnifiedEngineService` exposes engine state without leaking native bindings
   into screens.
+- Mobile reports connectivity opportunities after engine startup, foreground
+  entry, and network changes. Engine owns peer selection, retry, concurrency,
+  and cancellation. Manual refresh remains explicit; mobile does not run a
+  parallel retry loop or infer an overall refresh result from one online peer.
 - `UnifiedSpaceService` owns create, join, invitation, device, and leave-space
   operations.
 - `UnifiedContentService` is the single outbound entry for text, images, files,

--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ UniClip 的移动端早期 fork 自 [Jeric-X/syncclipboard-mobile](https://githu
 - Copyright (c) 2026 mkdir700（UniClip）
 
 详见 [LICENSE](./LICENSE)。
+
+## 自动连接验收
+
+[宿主接入与测试记录](docs/tests/automatic-peer-connections.md)说明前台、网络变化及共享 Engine 自动重连的接入与验证边界。

--- a/docs/tests/automatic-peer-connections.md
+++ b/docs/tests/automatic-peer-connections.md
@@ -1,0 +1,59 @@
+# 自动连接宿主接入与验收
+
+状态：实现完成，Mac 与 iOS 模拟器实际验收通过；其他实体平台未执行，尚未发布。
+
+## 责任
+
+连接、目标选择、重试和取消由同版本 Engine 负责。移动端只报告前台和网络变化，保留手动刷新，不再执行 30 秒循环，也不把某一设备 Online 合成一份虚假的全局刷新报告。
+
+- `src/platform/engine/engineRuntime.ts`：向原生报告机会；运行期间订阅 NetInfo，停止时取消订阅，忽略停止后迟到的手动刷新结果。
+- `src/features/sync/internal/p2pSyncAdapter.ts`：恢复原生生命周期后报告前台；后台暂停仍由原生生命周期处理。
+- `modules/uc-engine/src/index.ts`：三种固定机会的公共类型与薄转发。
+- `modules/uc-engine/ios/NativeLifecycleHost.swift`：真正前台回调先恢复，再通知 Engine；运行中的 Engine 同样得到通知。
+- Swift/Kotlin 模块把固定字符串映射到同版本 UniFFI 枚举；iOS 机会通知使用独立队列，避免被长手动操作阻塞。
+
+本改动依赖 Engine 的 `NotifyConnectivityOpportunity`，发布前必须采用包含该操作的同版本原生库；不能配合旧发布库直接上线。
+本地 Android 构建使用已有 `UC_ENGINE_LOCAL_AAR`，iOS 使用已有本地核心准备与完整校验流程，不修改用户其他工作区。
+
+## 已执行
+
+- 新增前台转发测试在原实现失败：没有向 Engine 报告机会；迁移后通过。
+- 新增迟到手动刷新测试先失败，修复后不会在停止后重新写入在线状态。
+- 全部 Jest：181 suites、1306 tests 通过。
+- TypeScript 检查与本次文件 ESLint 通过。
+- Swift Package：66 tests 通过，包括前台恢复、运行中再次前台、会话所有权与关闭。
+- 原有扩展测试暴露 `markSynchronizedWrite` 没有更新内存已处理修订；其调用方同时保存了磁盘修订。补齐内存记录后，重复同步写入不会再次排队，同时保留随后真实复制的处理。
+- 已核对原生 autolinking 指向当前工作区模块，不引用用户其他工作区的模块代码。
+
+## 复跑
+
+项目要求 Node 22.22.1；确保子进程的 `node`/`npx` 使用同一版本，避免旧 Node 拒绝 `.npmrc` 的类型剥离选项。
+
+```bash
+node --no-experimental-strip-types node_modules/jest/bin/jest.js --runInBand
+node node_modules/typescript/bin/tsc --noEmit
+swift test --package-path modules/uc-engine
+```
+
+模拟器/真机上的启动、前后台、断网与换网验证需单独记录；上述结果不等同于真实设备验收。
+
+## 最终本机验收（2026-09-11）
+
+本次工作区构建的完整 iOS 模拟器应用已签名、安装并实际运行，与本次 Desktop/Engine 的独立测试资料配对。完成同时冷启、两种先后启动、双方分别重启、iOS 前后台恢复六个场景，逐场景双向正文通过；自动连通后才通过真实界面“上传剪贴板”发送，未点击刷新或“立即同步”。启动/重启连通约 2–6 秒，前台恢复独立复验为 0.756 秒。
+
+最终 Jest 181 suites / 1306 tests、Swift Package 66 tests、TypeScript 和变更文件 lint 通过。真实 iOS 核心及完整应用构建通过；Android 原生包构建未完成，Windows/HarmonyOS 等实体组合未执行。
+
+测试准备必须包含模拟器粘贴权限和应用共享存储权限。本次使用本地签名，并以 `simctl privacy <设备> grant pasteboard <测试应用>` 设置测试粘贴权限。原有 Engine 启动会读取系统剪贴板；未完成系统确认时可能等待，不能从该等待推断自动重连失败。试验性的 JS 启动顺序调整已撤回，未包含在交付中。
+
+完整应用编译同时核对了新版可空传输记录编号，缺少编号的通知不映射为具体历史记录。当前 typed 日志导出不包含普通自动连接运行诊断，不能仅凭导出记录数量宣称两端连接证据完整。
+
+## 严格审查后来源更新（2026-09-11）
+
+Engine 修复已提交为 `ac9a50a787a3280e1657c9d56edd26b207bc67de`。从该干净提交重新构建的
+iOS 设备、Apple 芯片模拟器、Intel 模拟器三种包全部通过，并已通过现有本地准备入口安装到本工作区。
+来源记录核对为同一提交，未提交改动摘要为空；来源脚本的 2 项测试通过。
+
+本地包不能替代正式发布来源：`core-source.json` 仍指向已发布的 `v1.1.0-rc.14`，
+不能把旧包的版本和校验信息改写成新提交。正式采用尚待发布包含上述修复的新 Engine 包，
+再通过既有采用脚本统一更新来源与校验信息。Android 新包、完整应用重建与本轮产品配对场景未执行；
+前节产品模拟器验收属于初轮实现，不属于本次提交的产品运行证据。

--- a/modules/app-group-store/ios/Shared/LanServerCredentialStore.swift
+++ b/modules/app-group-store/ios/Shared/LanServerCredentialStore.swift
@@ -13,7 +13,8 @@ public enum LanServerCredentialStore {
         if let shared = try password(serverId: serverId) { return shared }
         guard let legacy = try read(serverId: serverId, accessGroup: nil) else { return nil }
         try setPassword(legacy, serverId: serverId)
-        try delete(serverId: serverId, accessGroup: nil)
+        // Keep the legacy copy until explicit removal. An unscoped delete would
+        // also match the shared copy we just saved.
         return legacy
     }
 
@@ -25,7 +26,7 @@ public enum LanServerCredentialStore {
         query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else { throw credentialError(status) }
-        try? delete(serverId: serverId, accessGroup: nil)
+        // Never clean up with an unscoped query here: it includes this group.
     }
 
     public static func deletePassword(serverId: String, includeLegacy: Bool = false) throws {

--- a/modules/uc-engine/android/src/main/java/expo/modules/ucengine/UcEngineModule.kt
+++ b/modules/uc-engine/android/src/main/java/expo/modules/ucengine/UcEngineModule.kt
@@ -30,6 +30,7 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 import org.json.JSONObject
+import uniffi.uc_engine_uniffi.ConnectivityOpportunity
 import uniffi.uc_engine_uniffi.BindingClipboardRepresentation
 import uniffi.uc_engine_uniffi.BindingClipboardRestoreMode
 import uniffi.uc_engine_uniffi.BindingClipboardRestoreOutcome
@@ -451,6 +452,15 @@ class UcEngineModule : Module() {
     AsyncFunction("nextEvent") { timeoutMs: Long ->
       requireEngine().nextEvent(timeoutMs.toULong())?.let(::eventMap)
     }.runOnQueue(appContext.backgroundCoroutineScope)
+    AsyncFunction("notifyConnectivityOpportunity") { reason: String ->
+      val opportunity = when (reason) {
+        "foreground" -> ConnectivityOpportunity.FOREGROUND
+        "system_wake" -> ConnectivityOpportunity.SYSTEM_WAKE
+        "network_changed" -> ConnectivityOpportunity.NETWORK_CHANGED
+        else -> throw IllegalArgumentException("Invalid connectivity opportunity")
+      }
+      requireEngine().notifyConnectivityOpportunity(opportunity)
+    }
     AsyncFunction("refreshPeerConnections") {
       val result = requireEngine().refreshPeerConnections()
       mapOf(

--- a/modules/uc-engine/ios/ExtensionSyncCoordinator.swift
+++ b/modules/uc-engine/ios/ExtensionSyncCoordinator.swift
@@ -77,6 +77,7 @@ public struct ExtensionClipboardRevisionTracker: Sendable {
   }
 
   public mutating func markSynchronizedWrite(_ revision: Int) {
+    lastHandledRevision = revision
     guard processingRevision == revision else { return }
     processingRevision = nil
   }

--- a/modules/uc-engine/ios/NativeLifecycleHost.swift
+++ b/modules/uc-engine/ios/NativeLifecycleHost.swift
@@ -66,6 +66,7 @@ protocol NativeEngineLifecycle {
   func lifecycleState() throws -> NativeEngineLifecycleState
   func suspend() throws
   func resume() throws
+  func notifyForegroundOpportunity() throws
 }
 
 enum NativeLifecycleError: Error, Equatable {
@@ -112,6 +113,10 @@ final class RuntimeOwnedNativeLifecycle: NativeEngineLifecycle {
       throw error
     }
   }
+  func notifyForegroundOpportunity() throws {
+    try engine.notifyForegroundOpportunity()
+  }
+
 }
 
 final class NativeLifecycleHost {
@@ -142,6 +147,7 @@ final class NativeLifecycleHost {
     guard let engine else { return }
     do {
       try resumeIfNeeded(engine)
+      if try engine.lifecycleState() == .running { try engine.notifyForegroundOpportunity() }
     } catch {
       report(error)
     }

--- a/modules/uc-engine/ios/SharedEngineHost.swift
+++ b/modules/uc-engine/ios/SharedEngineHost.swift
@@ -560,6 +560,7 @@ private final class ExtensionMobileEngineAdapter: ExtensionSyncEngine {
         totalBytes: totalBytes
       )
     case .transferStatusChanged(_, let entryId, _, let status, let reason):
+      guard let entryId else { return .other }
       return .outboundTransferStatusChanged(
         entryId: entryId,
         peerId: latestOutboundPeerByEntryId.removeValue(forKey: entryId),

--- a/modules/uc-engine/ios/Tests/NativeSystemHostTests.swift
+++ b/modules/uc-engine/ios/Tests/NativeSystemHostTests.swift
@@ -295,6 +295,7 @@ final class NativeSystemHostTests: XCTestCase {
 
     XCTAssertEqual(engine.suspendCalls, 1)
     XCTAssertEqual(engine.resumeCalls, 1)
+    XCTAssertEqual(engine.foregroundOpportunities, 2)
   }
 
   func testLifecycleHostMakesRepeatedForegroundRecoveryIdempotent() throws {
@@ -383,6 +384,8 @@ private final class FakeNativeEngineLifecycle: NativeEngineLifecycle {
   var recoverCalls = 0
   var suspendCalls = 0
   var resumeCalls = 0
+  var foregroundOpportunities = 0
+  func notifyForegroundOpportunity() throws { foregroundOpportunities += 1 }
   var onSuspend: (() -> Void)?
 
   init(state: NativeEngineLifecycleState) {

--- a/modules/uc-engine/ios/Tests/P2pRuntimeOwnershipTests.swift
+++ b/modules/uc-engine/ios/Tests/P2pRuntimeOwnershipTests.swift
@@ -106,6 +106,7 @@ private final class FakeRuntimeOwnership: NativeRuntimeOwnership {
 }
 
 private final class FakeOwnedEngine: NativeEngineLifecycle {
+  func notifyForegroundOpportunity() throws {}
   var state: NativeEngineLifecycleState = .running
   private(set) var resumeCalls = 0
   private let events: (String) -> Void

--- a/modules/uc-engine/ios/UcEngineModule.swift
+++ b/modules/uc-engine/ios/UcEngineModule.swift
@@ -15,6 +15,7 @@ public final class UcEngineModule: Module {
     beginBackgroundActivity: Self.beginBackgroundActivity
   )
   private let engineOperationQueue = DispatchQueue(label: "app.uniclipboard.uc-engine")
+  private let engineConnectivityQueue = DispatchQueue(label: "app.uniclipboard.uc-engine-connectivity")
   private let engineEventQueue = DispatchQueue(label: "app.uniclipboard.uc-engine-events")
   private let engines = NativeEngineRegistry<MobileEngine>()
 
@@ -185,6 +186,16 @@ public final class UcEngineModule: Module {
       try self.requireEngine().nextEvent(timeoutMs: timeoutMs).map(Self.eventMap)
     }.runOnQueue(engineEventQueue)
 
+    AsyncFunction("notifyConnectivityOpportunity") { (reason: String) in
+      let opportunity: ConnectivityOpportunity
+      switch reason {
+      case "foreground": opportunity = .foreground
+      case "system_wake": opportunity = .systemWake
+      case "network_changed": opportunity = .networkChanged
+      default: throw UcEngineInvalidConnectivityOpportunityException()
+      }
+      try self.requireEngine().notifyConnectivityOpportunity(reason: opportunity)
+    }.runOnQueue(engineConnectivityQueue)
     AsyncFunction("refreshPeerConnections") { () -> [String: Any] in
       let result = try self.requireEngine().refreshPeerConnections()
       return [
@@ -715,6 +726,10 @@ private final class AppleEngineLifecycle: NativeEngineLifecycle {
   func resume() throws {
     try owned.resume()
   }
+
+  func notifyForegroundOpportunity() throws {
+    try owned.notifyForegroundOpportunity()
+  }
 }
 
 private final class AppleMobileEngineLifecycle: NativeEngineLifecycle {
@@ -746,6 +761,10 @@ private final class AppleMobileEngineLifecycle: NativeEngineLifecycle {
 
   func resume() throws {
     try engine.resume()
+  }
+
+  func notifyForegroundOpportunity() throws {
+    try engine.notifyConnectivityOpportunity(reason: .foreground)
   }
 }
 
@@ -783,4 +802,8 @@ private extension NSLock {
     defer { unlock() }
     return try operation()
   }
+}
+
+private final class UcEngineInvalidConnectivityOpportunityException: Exception, @unchecked Sendable {
+  override var reason: String { "Invalid connectivity opportunity" }
 }

--- a/modules/uc-engine/src/index.ts
+++ b/modules/uc-engine/src/index.ts
@@ -1,3 +1,4 @@
+export type ConnectivityOpportunity = 'foreground' | 'system_wake' | 'network_changed';
 import { requireNativeModule } from 'expo-modules-core';
 
 export interface EngineConfig {
@@ -53,7 +54,12 @@ export type JoinSpaceRejectionReason =
   | 'removedBeforeActivation';
 
 export type JoinSpaceStatus =
-  | { type: 'active'; joinId: string; joinedSpace: JoinedSpace; peerUpgradeRequired: boolean }
+  | {
+      type: 'active';
+      joinId: string;
+      joinedSpace: JoinedSpace;
+      peerUpgradeRequired: boolean;
+    }
   | {
       type: 'pending';
       joinId: string;
@@ -154,7 +160,11 @@ export type ResendEntryOutcome =
     }
   | { kind: 'synchronizationDisabled' }
   | { kind: 'entryNotFound'; entryId: string }
-  | { kind: 'entryNotResendable'; entryId: string; reason: 'remoteOrigin' | 'payloadLost' }
+  | {
+      kind: 'entryNotResendable';
+      entryId: string;
+      reason: 'remoteOrigin' | 'payloadLost';
+    }
   | { kind: 'targetNotTrusted'; deviceId: string }
   | { kind: 'noEligibleTargets' };
 
@@ -172,7 +182,10 @@ export type EngineEvent =
       failure: { code: number; category: string; retryable: boolean };
     }
   | { type: 'refreshRequired'; reason: string }
-  | { type: 'fatal'; failure: { code: number; category: string; retryable: boolean } }
+  | {
+      type: 'fatal';
+      failure: { code: number; category: string; retryable: boolean };
+    }
   | {
       type: 'incomingEntry';
       entryId: string;
@@ -195,7 +208,12 @@ export type EngineEvent =
       state: string;
     }
   | { type: 'deliveryStatusChanged'; entryId: string; targetDeviceId: string }
-  | { type: 'peerPresenceChanged'; deviceId: string; state: string; atMs: number }
+  | {
+      type: 'peerPresenceChanged';
+      deviceId: string;
+      state: string;
+      atMs: number;
+    }
   | {
       type: 'transferProgress';
       transferId: string;
@@ -271,6 +289,7 @@ interface UcEngineNativeModule {
   cancelJoinSpace(joinId: string): Promise<void>;
   nextEvent(timeoutMs: number): Promise<EngineEvent | null>;
   refreshPeerConnections(): Promise<PeerConnectionRefresh>;
+  notifyConnectivityOpportunity(reason: ConnectivityOpportunity): Promise<void>;
   querySpaceState(): Promise<SpaceState>;
   listDevices(): Promise<Device[]>;
   queryDeviceGroupChoices(): Promise<DeviceTrustQueryResult>;
@@ -499,4 +518,8 @@ export function restoreClipboard(
 
 export function exportEntry(entryId: string, destinationHandle: string): Promise<void> {
   return NativeModule.exportEntry(entryId, destinationHandle);
+}
+
+export function notifyConnectivityOpportunity(reason: ConnectivityOpportunity): Promise<void> {
+  return NativeModule.notifyConnectivityOpportunity(reason);
 }

--- a/src/__tests__/LanCredentialCleanup.test.ts
+++ b/src/__tests__/LanCredentialCleanup.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('iOS LAN credential retention', () => {
+  it.each([
+    'modules/app-group-store/ios/Shared/LanServerCredentialStore.swift',
+    'targets/_shared/LanServerCredentialStore.swift',
+  ])('does not delete all accessible copies after saving in %s', (file) => {
+    const source = fs.readFileSync(path.resolve(file), 'utf8');
+    const saveAndMigration = source.slice(
+      source.indexOf('public static func loadAndMigratePassword'),
+      source.indexOf('public static func deletePassword')
+    );
+    // A nil access group matches every accessible group, including the new copy.
+    expect(saveAndMigration).not.toMatch(/delete\(serverId: serverId, accessGroup: nil\)/);
+  });
+});

--- a/src/__tests__/P2pSyncAdapter.test.ts
+++ b/src/__tests__/P2pSyncAdapter.test.ts
@@ -42,8 +42,19 @@ function dependencies(platform: 'android' | 'ios' = 'ios') {
     stop: jest.fn(async () => undefined),
     setBackgroundSyncPolicy: jest.fn(async () => undefined),
     resume: jest.fn(async () => undefined),
-    recoverPeerConnections: jest.fn(async () => ({ total: 1, online: 1, offline: 0, errors: 0 })),
-    refreshPeerConnections: jest.fn(async () => ({ total: 1, online: 1, offline: 0, errors: 0 })),
+    notifyConnectivityOpportunity: jest.fn(async (_reason: string) => undefined),
+    recoverPeerConnections: jest.fn(async () => ({
+      total: 1,
+      online: 1,
+      offline: 0,
+      errors: 0,
+    })),
+    refreshPeerConnections: jest.fn(async () => ({
+      total: 1,
+      online: 1,
+      offline: 0,
+      errors: 0,
+    })),
     cancelPeerRecovery: jest.fn(),
     subscribeEvents: jest.fn((listener: (event: unknown) => void) => {
       engineEventListener = listener;
@@ -78,6 +89,19 @@ function dependencies(platform: 'android' | 'ios' = 'ios') {
 }
 
 describe('P2pSyncAdapter', () => {
+  it('reports foreground opportunity without running a product retry loop', async () => {
+    const { P2pSyncAdapter } = require('../features/sync/internal/p2pSyncAdapter');
+    const deps = dependencies('ios');
+    const adapter = new P2pSyncAdapter(deps);
+    await adapter.start({
+      appVersion: '2.0.0',
+      profileId: 'default',
+      policy: { appState: 'active', backgroundSyncEnabled: true },
+    });
+    expect(deps.engine.notifyConnectivityOpportunity).toHaveBeenCalledWith('foreground');
+    expect(deps.engine.recoverPeerConnections).not.toHaveBeenCalled();
+    expect(deps.engine.refreshPeerConnections).not.toHaveBeenCalled();
+  });
   it('starts and refreshes the existing P2P runtime', async () => {
     const P2pSyncAdapter = loadP2pSyncAdapter();
     expect(P2pSyncAdapter).toBeDefined();
@@ -102,7 +126,7 @@ describe('P2pSyncAdapter', () => {
     expect(deps.engine.setBackgroundSyncPolicy).toHaveBeenCalledWith(true);
     expect(deps.engine.resume).toHaveBeenCalledTimes(1);
     expect(deps.space.refresh).toHaveBeenCalledTimes(1);
-    expect(deps.engine.recoverPeerConnections).toHaveBeenCalledTimes(1);
+    expect(deps.engine.notifyConnectivityOpportunity).toHaveBeenCalledWith('foreground');
   });
 
   it('normalizes current clipboard delivery', async () => {
@@ -136,7 +160,9 @@ describe('P2pSyncAdapter', () => {
       ): Promise<unknown>;
     };
 
-    await adapter.sendImportedText('shared text', 'TEXT_HASH', { targetIds: ['desktop-1'] });
+    await adapter.sendImportedText('shared text', 'TEXT_HASH', {
+      targetIds: ['desktop-1'],
+    });
 
     expect(deps.content.sendImportedText).toHaveBeenCalledWith('shared text', 'TEXT_HASH', {
       targetDeviceIds: ['desktop-1'],
@@ -171,16 +197,22 @@ describe('P2pSyncAdapter', () => {
         options: { targetIds: string[] }
       ): Promise<unknown>;
     };
-    const asset = { kind: 'file' as const, uri: 'file:///archive.zip', fileName: 'archive.zip' };
+    const asset = {
+      kind: 'file' as const,
+      uri: 'file:///archive.zip',
+      fileName: 'archive.zip',
+    };
 
-    await adapter.sendImportedAsset(asset, 'FILE_HASH', { targetIds: ['desktop-1'] });
+    await adapter.sendImportedAsset(asset, 'FILE_HASH', {
+      targetIds: ['desktop-1'],
+    });
 
     expect(deps.content.sendImportedAsset).toHaveBeenCalledWith(asset, 'FILE_HASH', {
       targetDeviceIds: ['desktop-1'],
     });
   });
 
-  it('cancels peer recovery when iOS leaves the foreground', async () => {
+  it('leaves background suspension to the native lifecycle', async () => {
     const P2pSyncAdapter = loadP2pSyncAdapter();
     expect(P2pSyncAdapter).toBeDefined();
     if (!P2pSyncAdapter) return;
@@ -190,9 +222,12 @@ describe('P2pSyncAdapter', () => {
       handleAppStateChange(policy: { appState: 'inactive'; backgroundSyncEnabled: boolean }): void;
     };
 
-    adapter.handleAppStateChange({ appState: 'inactive', backgroundSyncEnabled: false });
+    adapter.handleAppStateChange({
+      appState: 'inactive',
+      backgroundSyncEnabled: false,
+    });
 
-    expect(deps.engine.cancelPeerRecovery).toHaveBeenCalledTimes(1);
+    expect(deps.engine.cancelPeerRecovery).not.toHaveBeenCalled();
   });
 
   it('refreshes P2P projections and publishes generic engine events', async () => {
@@ -213,13 +248,18 @@ describe('P2pSyncAdapter', () => {
       policy: { appState: 'active', backgroundSyncEnabled: true },
     });
 
-    deps.emitEngineEvent({ type: 'peerPresenceChanged', deviceId: 'desktop-1' });
+    deps.emitEngineEvent({
+      type: 'peerPresenceChanged',
+      deviceId: 'desktop-1',
+    });
     deps.emitEngineEvent({ type: 'deviceTrustChanged', revision: 2 });
     deps.emitEngineEvent({ type: 'incomingEntry', entryId: 'entry-1' });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(deps.space.refreshDevices).toHaveBeenCalledTimes(1);
-    expect(deps.space.refresh).toHaveBeenLastCalledWith({ afterInvalidation: true });
+    expect(deps.space.refresh).toHaveBeenLastCalledWith({
+      afterInvalidation: true,
+    });
     expect(received).toEqual([
       { type: 'connectionChanged' },
       { type: 'configurationChanged' },
@@ -245,7 +285,7 @@ describe('P2pSyncAdapter', () => {
 
     await adapter.stop();
 
-    expect(deps.engine.cancelPeerRecovery).toHaveBeenCalledTimes(1);
+    expect(deps.engine.cancelPeerRecovery).not.toHaveBeenCalled();
     expect(deps.engineEventUnsubscribe).toHaveBeenCalledTimes(1);
     expect(deps.engine.stop).toHaveBeenCalledTimes(1);
   });
@@ -266,7 +306,10 @@ describe('P2pSyncAdapter', () => {
       policy: { appState: 'active', backgroundSyncEnabled: true },
     });
     await Promise.resolve();
-    deps.emitEngineEvent({ type: 'peerPresenceChanged', deviceId: 'desktop-1' });
+    deps.emitEngineEvent({
+      type: 'peerPresenceChanged',
+      deviceId: 'desktop-1',
+    });
     started.resolve();
     await start;
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -291,9 +334,15 @@ describe('P2pSyncAdapter', () => {
     });
     deps.space.refresh.mockClear();
     deps.space.refreshDevices.mockClear();
-    adapter.handleAppStateChange({ appState: 'background', backgroundSyncEnabled: false });
+    adapter.handleAppStateChange({
+      appState: 'background',
+      backgroundSyncEnabled: false,
+    });
 
-    deps.emitEngineEvent({ type: 'peerPresenceChanged', deviceId: 'desktop-1' });
+    deps.emitEngineEvent({
+      type: 'peerPresenceChanged',
+      deviceId: 'desktop-1',
+    });
     deps.emitEngineEvent({ type: 'deviceTrustChanged', revision: 3 });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -311,7 +360,10 @@ describe('P2pSyncAdapter', () => {
       handleAppStateChange(policy: unknown): void;
     };
 
-    adapter.handleAppStateChange({ appState: 'background', backgroundSyncEnabled: false });
+    adapter.handleAppStateChange({
+      appState: 'background',
+      backgroundSyncEnabled: false,
+    });
 
     expect(deps.engine.cancelPeerRecovery).not.toHaveBeenCalled();
   });
@@ -325,7 +377,11 @@ describe('P2pSyncAdapter', () => {
     const adapter = new P2pSyncAdapter(deps) as unknown as {
       observeClipboardChange(content: unknown, dispatch: boolean): Promise<unknown>;
     };
-    const content = { type: 'Text', text: 'captured', profileHash: 'TEXT_HASH' };
+    const content = {
+      type: 'Text',
+      text: 'captured',
+      profileHash: 'TEXT_HASH',
+    };
 
     await expect(adapter.observeClipboardChange(content, true)).resolves.toEqual({
       success: true,
@@ -342,7 +398,9 @@ describe('P2pSyncAdapter', () => {
     if (!P2pSyncAdapter) return;
 
     const deps = dependencies();
-    const adapter = new P2pSyncAdapter(deps) as unknown as { synchronize(): Promise<void> };
+    const adapter = new P2pSyncAdapter(deps) as unknown as {
+      synchronize(): Promise<void>;
+    };
 
     await adapter.synchronize();
 

--- a/src/__tests__/UnifiedEngineService.test.ts
+++ b/src/__tests__/UnifiedEngineService.test.ts
@@ -23,13 +23,6 @@ jest.mock('@/support/observability', () => {
   };
 });
 
-import * as observability from '@/support/observability';
-
-function engineLogger(): LoggerMock {
-  return (observability as unknown as { __unifiedEngineTestLogger: LoggerMock })
-    .__unifiedEngineTestLogger;
-}
-
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((done) => {
@@ -64,81 +57,39 @@ function refreshReport(online: number): PeerConnectionRefresh {
 }
 
 describe('UnifiedEngineService', () => {
-  it('keeps connecting after an offline refresh and becomes online on a later refresh', async () => {
+  it('reports an opportunity without polling or synthesizing online', async () => {
     jest.useFakeTimers();
     const pendingEvent = deferred<EngineEvent | null>();
     const snapshots: UnifiedEngineSnapshot[] = [];
-    const refreshPeerConnections = jest
-      .fn<UnifiedEngineApi['refreshPeerConnections']>()
-      .mockResolvedValueOnce(refreshReport(0))
-      .mockResolvedValueOnce(refreshReport(1));
+    const notifyConnectivityOpportunity = jest.fn(async (_reason: string) => undefined);
+    const refreshPeerConnections = jest.fn(async () => refreshReport(0));
     const service = new UnifiedEngineService(
       {
         start: async () => undefined,
         shutdown: async () => pendingEvent.resolve(null),
         resume: async () => undefined,
         nextEvent: () => pendingEvent.promise,
+        notifyConnectivityOpportunity,
         refreshPeerConnections,
       },
       (snapshot) => snapshots.push(snapshot)
     );
-
     await service.start(config());
-    const recovery = service.recoverPeerConnections({ timeoutMs: 5_000, retryDelayMs: 1_000 });
-    await Promise.resolve();
-
-    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('connecting');
-    expect(refreshPeerConnections).toHaveBeenCalledTimes(1);
-
-    await jest.advanceTimersByTimeAsync(1_000);
-    await expect(recovery).resolves.toEqual(refreshReport(1));
-    expect(refreshPeerConnections).toHaveBeenCalledTimes(2);
-    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('online');
+    await service.notifyConnectivityOpportunity('foreground');
+    await jest.advanceTimersByTimeAsync(30_000);
+    expect(notifyConnectivityOpportunity).toHaveBeenCalledTimes(1);
+    expect(notifyConnectivityOpportunity).toHaveBeenCalledWith('foreground');
+    expect(refreshPeerConnections).not.toHaveBeenCalled();
+    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('idle');
     await service.stop();
+    await service.notifyConnectivityOpportunity('foreground');
+    expect(notifyConnectivityOpportunity).toHaveBeenCalledTimes(1);
     jest.useRealTimers();
   });
 
-  it('finishes recovery immediately when a peer becomes online', async () => {
-    jest.useFakeTimers();
-    const event = deferred<EngineEvent | null>();
-    const refresh = deferred<PeerConnectionRefresh>();
-    const snapshots: UnifiedEngineSnapshot[] = [];
-    const service = new UnifiedEngineService(
-      {
-        start: async () => undefined,
-        shutdown: async () => event.resolve(null),
-        resume: async () => undefined,
-        nextEvent: () => event.promise,
-        refreshPeerConnections: () => refresh.promise,
-      },
-      (snapshot) => snapshots.push(snapshot)
-    );
-
-    await service.start(config());
-    const recovery = service.recoverPeerConnections({ timeoutMs: 5_000, retryDelayMs: 1_000 });
-    event.resolve({
-      type: 'peerPresenceChanged',
-      deviceId: 'desktop-device-id',
-      state: 'online',
-      atMs: 123_456,
-    });
-    await expect(recovery).resolves.toEqual(expect.objectContaining({ online: 1 }));
-    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('online');
-    expect(engineLogger().info).toHaveBeenCalledWith(
-      expect.stringContaining('peer connected deviceId=desktop-device-id')
-    );
-    expect(engineLogger().info).toHaveBeenCalledWith(
-      expect.stringContaining('customRelayConfigured=false')
-    );
-
-    refresh.resolve(refreshReport(0));
-    await service.stop();
-    jest.useRealTimers();
-  });
-
-  it('reports offline only after the foreground recovery budget expires', async () => {
-    jest.useFakeTimers();
+  it('does not publish a late manual refresh result after stopping', async () => {
     const pendingEvent = deferred<EngineEvent | null>();
+    const refreshed = deferred<PeerConnectionRefresh>();
     const snapshots: UnifiedEngineSnapshot[] = [];
     const service = new UnifiedEngineService(
       {
@@ -146,63 +97,44 @@ describe('UnifiedEngineService', () => {
         shutdown: async () => pendingEvent.resolve(null),
         resume: async () => undefined,
         nextEvent: () => pendingEvent.promise,
-        refreshPeerConnections: async () => refreshReport(0),
+        notifyConnectivityOpportunity: async () => undefined,
+        refreshPeerConnections: () => refreshed.promise,
       },
       (snapshot) => snapshots.push(snapshot)
     );
-
     await service.start(config());
-    const recovery = service.recoverPeerConnections({ timeoutMs: 2_000, retryDelayMs: 1_000 });
-    await Promise.resolve();
-    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('connecting');
-
-    await jest.advanceTimersByTimeAsync(2_000);
-    await expect(recovery).resolves.toEqual(refreshReport(0));
-    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('offline');
+    const refresh = service.refreshPeerConnections();
     await service.stop();
-    jest.useRealTimers();
+    refreshed.resolve(refreshReport(1));
+    await refresh;
+    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('idle');
   });
 
-  it('does not let a cancelled recovery overwrite a newer online result', async () => {
-    jest.useFakeTimers();
+  it('forwards network changes and removes the listener when stopping', async () => {
+    const NetInfo = require('@react-native-community/netinfo').default;
+    NetInfo.addEventListener.mockClear();
     const pendingEvent = deferred<EngineEvent | null>();
-    const staleRefresh = deferred<PeerConnectionRefresh>();
-    const snapshots: UnifiedEngineSnapshot[] = [];
-    const refreshPeerConnections = jest
-      .fn<UnifiedEngineApi['refreshPeerConnections']>()
-      .mockImplementationOnce(() => staleRefresh.promise)
-      .mockResolvedValueOnce(refreshReport(1));
-    const service = new UnifiedEngineService(
-      {
-        start: async () => undefined,
-        shutdown: async () => pendingEvent.resolve(null),
-        resume: async () => undefined,
-        nextEvent: () => pendingEvent.promise,
-        refreshPeerConnections,
-      },
-      (snapshot) => snapshots.push(snapshot)
-    );
-
+    const notifyConnectivityOpportunity = jest.fn(async (_reason: string) => undefined);
+    const service = new UnifiedEngineService({
+      start: async () => undefined,
+      shutdown: async () => pendingEvent.resolve(null),
+      resume: async () => undefined,
+      nextEvent: () => pendingEvent.promise,
+      notifyConnectivityOpportunity,
+      refreshPeerConnections: async () => refreshReport(0),
+    });
     await service.start(config());
-    const staleRecovery = service.recoverPeerConnections({
-      timeoutMs: 5_000,
-      retryDelayMs: 1_000,
-    });
-    service.cancelPeerRecovery();
-    const currentRecovery = service.recoverPeerConnections({
-      timeoutMs: 5_000,
-      retryDelayMs: 1_000,
-    });
-
-    await expect(staleRecovery).resolves.toEqual(expect.objectContaining({ online: 0 }));
-    await expect(currentRecovery).resolves.toEqual(refreshReport(1));
-    staleRefresh.resolve(refreshReport(0));
+    const listener = NetInfo.addEventListener.mock.calls[0][0];
+    const unsubscribe = NetInfo.addEventListener.mock.results[0].value;
+    listener({ isConnected: true });
     await Promise.resolve();
-    expect(snapshots.at(-1)?.peerConnectionStatus).toBe('online');
-
+    expect(notifyConnectivityOpportunity).toHaveBeenCalledWith('network_changed');
     await service.stop();
-    jest.useRealTimers();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    listener({ isConnected: true });
+    expect(notifyConnectivityOpportunity).toHaveBeenCalledTimes(1);
   });
+
   it('starts once, publishes native state changes, and shuts down cleanly', async () => {
     const pendingEvent = deferred<EngineEvent | null>();
     const start = jest.fn(async () => undefined);
@@ -230,7 +162,11 @@ describe('UnifiedEngineService', () => {
 
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(snapshots.at(-1)).toEqual(
-      expect.objectContaining({ status: 'stopped', isStarted: false, lastError: null })
+      expect.objectContaining({
+        status: 'stopped',
+        isStarted: false,
+        lastError: null,
+      })
     );
   });
 
@@ -260,7 +196,11 @@ describe('UnifiedEngineService', () => {
 
     expect(failed.refreshRevision).toBe(1);
     expect(failed.lastChangedKind).toBe('clipboard');
-    expect(failed.fatalFailure).toEqual({ code: 7001, category: 'runtime', retryable: false });
+    expect(failed.fatalFailure).toEqual({
+      code: 7001,
+      category: 'runtime',
+      retryable: false,
+    });
     expect(shutdown).not.toHaveBeenCalled();
 
     await service.stop();

--- a/src/features/sync/internal/p2pSyncAdapter.ts
+++ b/src/features/sync/internal/p2pSyncAdapter.ts
@@ -1,4 +1,9 @@
-import type { EngineConfig, EngineEvent, SendReport } from '@/platform/engine';
+import type {
+  EngineConfig,
+  EngineEvent,
+  SendReport,
+  ConnectivityOpportunity,
+} from '@/platform/engine';
 import {
   p2pDeliveryCountsFromReport,
   p2pDeliveryStateFromReport,
@@ -25,9 +30,8 @@ interface P2pEnginePort {
   stop(): Promise<void>;
   setBackgroundSyncPolicy(enabled: boolean): Promise<void>;
   resume(): Promise<void>;
-  recoverPeerConnections(): Promise<unknown>;
+  notifyConnectivityOpportunity(reason: ConnectivityOpportunity): Promise<void>;
   refreshPeerConnections(): Promise<unknown>;
-  cancelPeerRecovery(): void;
   subscribeEvents(listener: (event: EngineEvent) => void): () => void;
 }
 
@@ -93,24 +97,16 @@ export class P2pSyncAdapter implements SyncAdapter {
     }
     const space = await this.dependencies.space.refresh();
     log.info('P2P space state', { deviceCount: space.devices.length });
-    void this.dependencies.engine.recoverPeerConnections().then(
-      (report) => log.info('P2P receiver recovery finished', report),
-      (error) => log.error('Failed to recover P2P peer connections:', error)
-    );
+    if (policy.appState === 'active') {
+      await this.dependencies.engine.notifyConnectivityOpportunity('foreground');
+    }
   }
 
   handleAppStateChange(policy: SyncRuntimePolicy): void {
     this.policy = policy;
-    if (
-      this.dependencies.platform === 'ios' &&
-      (policy.appState === 'inactive' || policy.appState === 'background')
-    ) {
-      this.dependencies.engine.cancelPeerRecovery();
-    }
   }
 
   async stop(): Promise<void> {
-    this.dependencies.engine.cancelPeerRecovery();
     this.engineEventsUnsubscribe?.();
     this.engineEventsUnsubscribe = null;
     await this.dependencies.engine.stop();
@@ -215,7 +211,10 @@ export class P2pSyncAdapter implements SyncAdapter {
     }
 
     if (event.type === 'fatal') {
-      this.publish({ type: 'failed', message: `${event.failure.category}:${event.failure.code}` });
+      this.publish({
+        type: 'failed',
+        message: `${event.failure.category}:${event.failure.code}`,
+      });
     }
   }
 

--- a/src/platform/engine/engineRuntime.ts
+++ b/src/platform/engine/engineRuntime.ts
@@ -1,4 +1,10 @@
-import type { EngineConfig, EngineEvent, PeerConnectionRefresh } from './contracts';
+import NetInfo from '@react-native-community/netinfo';
+import type {
+  EngineConfig,
+  EngineEvent,
+  PeerConnectionRefresh,
+  ConnectivityOpportunity,
+} from './contracts';
 import { AppState } from 'react-native';
 import { createLogger } from '@/support/observability';
 import { useSettingsStore } from '@/features/settings';
@@ -18,6 +24,7 @@ export interface UnifiedEngineApi {
   setBackgroundSyncEnabled(enabled: boolean, appIsBackground: boolean): Promise<void>;
   nextEvent(timeoutMs?: number): Promise<EngineEvent | null>;
   refreshPeerConnections(): Promise<PeerConnectionRefresh>;
+  notifyConnectivityOpportunity(reason: ConnectivityOpportunity): Promise<void>;
 }
 
 type SnapshotPublisher = (snapshot: UnifiedEngineSnapshot) => void;
@@ -25,30 +32,6 @@ type EngineEventSubscriber = (event: EngineEvent) => void;
 
 const DEFAULT_EVENT_TIMEOUT_MS = 250;
 const SHUTDOWN_DEADLINE_MS = 5_000;
-const DEFAULT_PEER_RECOVERY_TIMEOUT_MS = 30_000;
-const DEFAULT_PEER_RECOVERY_RETRY_DELAY_MS = 1_000;
-
-export interface PeerRecoveryOptions {
-  timeoutMs?: number;
-  retryDelayMs?: number;
-}
-
-type PeerRecoverySignal = 'online' | 'cancelled';
-
-function emptyPeerRefresh(): PeerConnectionRefresh {
-  return { total: 0, online: 0, offline: 0, errors: 0 };
-}
-
-function onlinePeerRefresh(): PeerConnectionRefresh {
-  return { total: 1, online: 1, offline: 0, errors: 0 };
-}
-
-function delay(ms: number): Promise<'elapsed'> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve('elapsed'), ms);
-  });
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -66,12 +49,7 @@ export class UnifiedEngineService {
   private nativeStarted = false;
   private startInFlight: Promise<void> | null = null;
   private eventLoop: Promise<void> | null = null;
-  private peerRecoveryGeneration = 0;
-  private peerRecoveryInFlight: Promise<PeerConnectionRefresh> | null = null;
-  private peerRecoverySignal: {
-    generation: number;
-    resolve: (signal: PeerRecoverySignal) => void;
-  } | null = null;
+  private networkUnsubscribe: (() => void) | null = null;
   private readonly eventSubscribers = new Set<EngineEventSubscriber>();
 
   constructor(
@@ -87,7 +65,10 @@ export class UnifiedEngineService {
     if (this.startInFlight) return this.startInFlight;
 
     const generation = ++this.generation;
-    this.snapshot = { ...createInitialUnifiedEngineSnapshot(), status: 'starting' };
+    this.snapshot = {
+      ...createInitialUnifiedEngineSnapshot(),
+      status: 'starting',
+    };
     this.publishSnapshot();
 
     const attempt = this.startNative(config, generation);
@@ -104,10 +85,11 @@ export class UnifiedEngineService {
   }
 
   refreshPeerConnections(): Promise<PeerConnectionRefresh> {
-    if (this.peerRecoveryInFlight) return this.peerRecoveryInFlight;
+    const generation = this.generation;
     this.updatePeerConnectionStatus('connecting');
     return this.api.refreshPeerConnections().then(
       (report) => {
+        if (generation !== this.generation || !this.nativeStarted) return report;
         this.updatePeerConnectionStatus(report.online > 0 ? 'online' : 'offline');
         if (report.online > 0) {
           log.info(
@@ -119,45 +101,16 @@ export class UnifiedEngineService {
         return report;
       },
       (error) => {
-        this.updatePeerConnectionStatus('offline');
+        if (generation === this.generation && this.nativeStarted)
+          this.updatePeerConnectionStatus('offline');
         throw error;
       }
     );
   }
 
-  recoverPeerConnections(options: PeerRecoveryOptions = {}): Promise<PeerConnectionRefresh> {
-    if (this.peerRecoveryInFlight) return this.peerRecoveryInFlight;
-
-    const generation = ++this.peerRecoveryGeneration;
-    let resolveSignal!: (signal: PeerRecoverySignal) => void;
-    const signal = new Promise<PeerRecoverySignal>((resolve) => {
-      resolveSignal = resolve;
-    });
-    this.peerRecoverySignal = { generation, resolve: resolveSignal };
-    this.updatePeerConnectionStatus('connecting');
-
-    const recovery = this.runPeerRecovery(
-      generation,
-      signal,
-      Math.max(0, options.timeoutMs ?? DEFAULT_PEER_RECOVERY_TIMEOUT_MS),
-      Math.max(0, options.retryDelayMs ?? DEFAULT_PEER_RECOVERY_RETRY_DELAY_MS)
-    );
-    this.peerRecoveryInFlight = recovery;
-    void recovery.then(
-      () => this.clearPeerRecovery(recovery, generation),
-      () => this.clearPeerRecovery(recovery, generation)
-    );
-    return recovery;
-  }
-
-  cancelPeerRecovery(): void {
-    ++this.peerRecoveryGeneration;
-    this.peerRecoverySignal?.resolve('cancelled');
-    this.peerRecoverySignal = null;
-    this.peerRecoveryInFlight = null;
-    if (this.snapshot.peerConnectionStatus === 'connecting') {
-      this.updatePeerConnectionStatus('idle');
-    }
+  notifyConnectivityOpportunity(reason: ConnectivityOpportunity): Promise<void> {
+    if (!this.nativeStarted) return Promise.resolve();
+    return this.api.notifyConnectivityOpportunity(reason);
   }
 
   resume(): Promise<void> {
@@ -176,7 +129,8 @@ export class UnifiedEngineService {
   }
 
   async stop(): Promise<void> {
-    this.cancelPeerRecovery();
+    this.networkUnsubscribe?.();
+    this.networkUnsubscribe = null;
     ++this.generation;
 
     const startInFlight = this.startInFlight;
@@ -213,7 +167,11 @@ export class UnifiedEngineService {
 
     if (shutdownError) {
       const message = errorMessage(shutdownError);
-      this.updateSnapshot({ status: 'failed', isStarted: false, lastError: message });
+      this.updateSnapshot({
+        status: 'failed',
+        isStarted: false,
+        lastError: message,
+      });
       log.error('Failed to stop the P2P engine:', shutdownError);
       throw shutdownError;
     }
@@ -228,7 +186,16 @@ export class UnifiedEngineService {
       if (generation !== this.generation) return;
 
       this.nativeStarted = true;
-      this.updateSnapshot({ status: 'running', isStarted: true, lastError: null });
+      this.networkUnsubscribe = NetInfo.addEventListener(() => {
+        void this.notifyConnectivityOpportunity('network_changed').catch(() => {
+          log.warn('Failed to report a network connectivity opportunity');
+        });
+      });
+      this.updateSnapshot({
+        status: 'running',
+        isStarted: true,
+        lastError: null,
+      });
       const eventLoop = this.consumeEvents(generation);
       this.eventLoop = eventLoop;
       void eventLoop.then(
@@ -238,7 +205,11 @@ export class UnifiedEngineService {
     } catch (error) {
       if (generation === this.generation) {
         const message = errorMessage(error);
-        this.updateSnapshot({ status: 'failed', isStarted: false, lastError: message });
+        this.updateSnapshot({
+          status: 'failed',
+          isStarted: false,
+          lastError: message,
+        });
         log.error('Failed to start the P2P engine:', error);
       }
       throw error;
@@ -275,7 +246,11 @@ export class UnifiedEngineService {
 
     switch (event.type) {
       case 'stateChanged':
-        if (event.state === 'stopped') this.nativeStarted = false;
+        if (event.state === 'stopped') {
+          this.nativeStarted = false;
+          this.networkUnsubscribe?.();
+          this.networkUnsubscribe = null;
+        }
         this.updateSnapshot({
           status: event.state,
           isStarted: event.state !== 'stopped',
@@ -313,20 +288,16 @@ export class UnifiedEngineService {
           ...(event.state === 'online' ? { peerConnectionStatus: 'online' as const } : {}),
           refreshRevision: this.snapshot.refreshRevision + 1,
         });
-        if (event.state === 'online') {
-          log.info(
-            `peer connected deviceId=${
-              event.deviceId
-            } ${relayContext()} (actual relay url is logged by the engine)`
-          );
-          this.peerRecoverySignal?.resolve('online');
-        }
         break;
       case 'transferProgress':
         this.updateSnapshot({ lastEvent: event, lastChangedKind: event.type });
         break;
       case 'fatal':
-        this.updateSnapshot({ status: 'failed', lastEvent: event, fatalFailure: event.failure });
+        this.updateSnapshot({
+          status: 'failed',
+          lastEvent: event,
+          fatalFailure: event.failure,
+        });
         log.error('The P2P engine reported a fatal failure:', event.failure);
         break;
       case 'lifecycleFailed':
@@ -347,69 +318,10 @@ export class UnifiedEngineService {
     this.publishSnapshot();
   }
 
-  private async runPeerRecovery(
-    generation: number,
-    signal: Promise<PeerRecoverySignal>,
-    timeoutMs: number,
-    retryDelayMs: number
-  ): Promise<PeerConnectionRefresh> {
-    const deadline = Date.now() + timeoutMs;
-    let lastReport = emptyPeerRefresh();
-
-    while (generation === this.peerRecoveryGeneration) {
-      const remainingMs = Math.max(0, deadline - Date.now());
-      if (remainingMs === 0) break;
-
-      const outcome = await Promise.race([
-        this.api.refreshPeerConnections().then(
-          (report) => ({ kind: 'report' as const, report }),
-          (error: unknown) => ({ kind: 'error' as const, error })
-        ),
-        signal.then((value) =>
-          value === 'online' ? ({ kind: 'online' } as const) : ({ kind: 'cancelled' } as const)
-        ),
-        delay(remainingMs).then(() => ({ kind: 'timeout' as const })),
-      ]);
-
-      if (generation !== this.peerRecoveryGeneration || outcome.kind === 'cancelled') {
-        return lastReport;
-      }
-      if (outcome.kind === 'online') {
-        return onlinePeerRefresh();
-      }
-      if (outcome.kind === 'timeout') break;
-      if (outcome.kind === 'report') {
-        lastReport = outcome.report;
-        if (outcome.report.online > 0) {
-          this.updatePeerConnectionStatus('online');
-          return outcome.report;
-        }
-      } else {
-        log.warn('Peer recovery refresh failed:', outcome.error);
-      }
-
-      const delayMs = Math.min(retryDelayMs, Math.max(0, deadline - Date.now()));
-      if (delayMs === 0) break;
-      const waitOutcome = await Promise.race([signal, delay(delayMs)]);
-      if (generation !== this.peerRecoveryGeneration || waitOutcome === 'cancelled') {
-        return lastReport;
-      }
-      if (waitOutcome === 'online') return onlinePeerRefresh();
-    }
-
-    if (generation === this.peerRecoveryGeneration) this.updatePeerConnectionStatus('offline');
-    return lastReport;
-  }
-
   private updatePeerConnectionStatus(status: PeerConnectionStatus): void {
     if (this.snapshot.peerConnectionStatus !== status) {
       this.updateSnapshot({ peerConnectionStatus: status });
     }
-  }
-
-  private clearPeerRecovery(recovery: Promise<PeerConnectionRefresh>, generation: number): void {
-    if (this.peerRecoveryInFlight === recovery) this.peerRecoveryInFlight = null;
-    if (this.peerRecoverySignal?.generation === generation) this.peerRecoverySignal = null;
   }
 
   private publishSnapshot(): void {

--- a/targets/_shared/LanServerCredentialStore.swift
+++ b/targets/_shared/LanServerCredentialStore.swift
@@ -13,7 +13,8 @@ public enum LanServerCredentialStore {
         if let shared = try password(serverId: serverId) { return shared }
         guard let legacy = try read(serverId: serverId, accessGroup: nil) else { return nil }
         try setPassword(legacy, serverId: serverId)
-        try delete(serverId: serverId, accessGroup: nil)
+        // Keep the legacy copy until explicit removal. An unscoped delete would
+        // also match the shared copy we just saved.
         return legacy
     }
 
@@ -25,7 +26,7 @@ public enum LanServerCredentialStore {
         query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else { throw credentialError(status) }
-        try? delete(serverId: serverId, accessGroup: nil)
+        // Never clean up with an unscoped query here: it includes this group.
     }
 
     public static func deletePassword(serverId: String, includeLegacy: Bool = false) throws {


### PR DESCRIPTION
移动端把启动完成、进入前台和网络变化转交给 Engine，并删除产品侧原有的重复连接循环。手动刷新继续保留，连接对象、重试和最终结果由 Engine 统一负责。

iOS 与 Android 原生桥接均已接入固定机会；Jest 181 个测试套件共 1306 项、Swift Package 66 项、类型与格式检查通过。最新 Engine 提交生成的三种 iOS 包已通过本地来源校验；正式发布包更新需在 Engine 新版本发布后完成。

关联 PR：

- Engine: https://github.com/UniClipboard/Engine/pull/61
- Desktop: https://github.com/UniClipboard/UniClipboard/pull/1656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connectivity changes, foreground entry, and system wake events now notify the engine to evaluate peer connections automatically.
  - Added support for connectivity opportunity notifications across iOS, Android, and shared platform APIs.

- **Bug Fixes**
  - Prevented LAN credentials from being accidentally removed during migration or updates.
  - Improved handling of incomplete transfer status events.
  - Prevented stale refresh results from appearing after the engine stops.

- **Documentation**
  - Added acceptance and verification guidance for automatic peer connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->